### PR TITLE
Added functions for basis transformation, modified ewpc_mapSpots code.

### DIFF
--- a/Strain_from_D.m
+++ b/Strain_from_D.m
@@ -1,0 +1,125 @@
+function [ StrainComponents,StrainTensors] = Strain_from_D( D, latticeCoords )
+% Makes maps of strain tensor components from the distortion matrix
+%   inputs:
+%       D -- distortion matrix after rotation and transformation to correct
+%       basis vectors
+%       latticeCoords -- choose coordinate system to reference
+%                        strain to.  Value 0 selects "image 
+%                        coordinates", with the 1,2 directions 
+%                        corresponding to image x1,x2.  Value 1 selects
+%                        "lattice coordinates", where the 1,2 directions
+%                        refer to the reference directions.
+%   outputs:
+%       StrainComponents -- struct containing 2D arrays (images) of the
+%               strain tensor components, rotation, and strain ellipse 
+%               parameters, including:
+%                   Eps11 -- The first diagonal element of the strain tensor
+%                   Eps22 -- The second diagonal element of the strain tensor
+%                   Eps12 -- The 2D shear component of the strain tensor (1,2) off
+%                            diagonal
+%                   Theta -- The rotation relative to the reference, decomposed from
+%                            the strain tensor, in degrees
+%                   minAx -- semi-minor axis length of the strain ellipse
+%                   majAx -- semi-major axis length of the strain ellipse
+%                   strainAngle -- angle of the strain ellipse semi-major
+%                                  axis
+%       StrainTensors -- struct array containing the strain tensor 'E' and
+%                        rotation matrix 'R' describing the distortion at each
+%                        real space position, along with the eigenvalues
+%                        'evals' and eigenvectors 'evecs' of the strain tensor
+%
+%This function is part of the PC-STEM Package by Elliot Padgett in the 
+%Muller Group at Cornell University.  Last updated Sept 17, 2021.
+
+%initialize data info
+[Nx1,Nx2] = size(D.m11);
+
+%prealocate results structs
+StrainComponents = struct('Eps11', nan(Nx1,Nx2), 'Eps22', nan(Nx1,Nx2),...
+                          'Eps12', nan(Nx1,Nx2), 'Theta', nan(Nx1,Nx2),...
+                          'majAx', nan(Nx1,Nx2), 'minAx', nan(Nx1,Nx2),...
+                          'strainAngle', nan(Nx1,Nx2));
+StrainTensors = struct('E',cell(Nx1,Nx2),'R',cell(Nx1,Nx2),...
+    'evals',cell(Nx1,Nx2),'evecs',cell(Nx1,Nx2));
+
+%calculate strain across map
+for j=1:Nx1
+    for k=1:Nx2
+        
+        X = zeros(2,2);
+        X(1,1) = D.m11(j,k);
+        X(1,2) = D.m12(j,k);
+        X(2,1) = D.m21(j,k);
+        X(2,2) = D.m22(j,k);
+                   
+        [R,U,V] = poldecomp(X); % D = R*U = V*R.  R is a rotation.
+        %V is the strain in "world coordinates" and is independent of
+        %the reference orientation. U is the strain in "lattice
+        %coordinates", corresponding to the reference directions
+
+        if latticeCoords
+            E = U-eye(2); % strain tensor
+        else
+            E = V-eye(2); % strain tensor
+        end
+
+        StrainTensors(j,k).R = R;
+        StrainTensors(j,k).E = E;
+
+        %get strain tensor elements
+        StrainComponents.Eps11(j,k) = E(1,1); %fractional stretch
+        StrainComponents.Eps22(j,k) = E(2,2); %fractional stretch
+        StrainComponents.Eps12(j,k) = E(1,2); %fractional shear
+        StrainComponents.Theta(j,k) = atan2d(R(2,1),R(1,1)); %rotation in degrees
+
+        %get strain elipse parameters
+        [v,d]=eig(E);
+        [evals,sorting] = sort([d(1,1),d(2,2)]); %sorts in ascending order
+        evecs = v(:,sorting);
+        StrainComponents.minAx(j,k) = evals(1); 
+        StrainComponents.majAx(j,k) = evals(2); 
+        StrainComponents.strainAngle(j,k) = atand(evecs(2,2)/evecs(1,2));
+
+        StrainTensors(j,k).evecs = evecs(:,2);
+        StrainTensors(j,k).evals = evals';
+            
+    end
+end
+end
+
+
+
+function [R, U, V] = poldecomp(F)
+%POLDECOMP  Performs the polar decomposition of a regular square matrix.
+%   [R U V] = POLDECOMP(F) factorizes a non-singular square matrix F such
+%   that F=R*U and F=V*R, where
+%   U and V are symmetric, positive definite matrices and
+%   R is a rotational matrix
+%
+%   See also EIG, DIAG, REPMAT
+
+
+% This kind of decomposition is often used in continuum mechanics so it is
+% convenient to comment the code that way. From now, we use the matrix
+% formalism of tensors. C is the right Cauchy-Green deformation tensor,
+% F is the deformation tensor, lambda is the stretch.
+%
+%Copyright (c) 2014, Zoltán Csáti
+
+% Check input
+[m n] = size(F);
+if m ~= n
+    error('Matrix must be square.');
+end
+
+C = F'*F;
+[Q0, lambdasquare] = eig(C);
+lambda = sqrt(diag((lambdasquare))); % extract the components
+% Uinv is the inverse of U and is constructed with the help of Q0. Uinv is
+% produced in the same base as F not in the base of its eigenvectors.
+Uinv = repmat(1./lambda',size(F,1),1).*Q0*Q0';
+% Using the definition, R, U and V can now be calculated
+R = F*Uinv;
+U = R'*F;
+V = F*R';
+end

--- a/basis_non_orth.m
+++ b/basis_non_orth.m
@@ -1,0 +1,45 @@
+function [ D_final ] = basis_non_orth( D_rot, angle )
+
+%Basis transformation of the distortion matrix to transform from a pair of
+%non-orthogonal basis vectors to orthogonal basis vectors. Changes basis vector #1 to be
+% perpendicular to #2.
+
+%   inputs:
+%       D_rot -- Distortion matrix that has been rotated to orient basis vector #2 along the required direction 
+%       angle -- angle between basis vectors #1 and #2
+
+%   outputs:
+%       D_final -- Final distortion matrix with basis vectors orthogonal to
+%       each other
+
+%%This function is part of the PC-STEM Package by Elliot Padgett in the 
+%Muller Group at Cornell University. Function added by Hari (Muller group).
+%Last updated Sept 17, 2021.
+
+[N_x1, N_x2] = size(D_rot.m11);
+
+D_final = struct('m11', nan(N_x1,N_x2), 'm22', nan(N_x1,N_x2),'m12', nan(N_x1,N_x2), 'm21', nan(N_x1,N_x2));
+
+transform = zeros(2,2);
+transform(1,1) = sind(angle);
+transform(1,2) = 0;
+transform(2,1) = cosd(angle);
+transform(2,2) = 1;
+
+for i =1:N_x1
+    for j = 1:N_x2
+       
+       mat(1,1) = D_rot.m11(i,j);
+       mat(1,2) = D_rot.m12(i,j);
+       mat(2,1) = D_rot.m21(i,j);
+       mat(2,2) = D_rot.m22(i,j);
+       
+       temp_mat = transform * mat / transform;
+       
+       D_final.m11(i,j) = temp_mat(1,1);
+       D_final.m12(i,j) = temp_mat(1,2);
+       D_final.m21(i,j) = temp_mat(2,1);
+       D_final.m22(i,j) = temp_mat(2,2);
+    end
+end
+end

--- a/basis_rot.m
+++ b/basis_rot.m
@@ -1,0 +1,45 @@
+function [ D_rot ] = basis_rot( D, angle )
+
+%Basis transformation of the distortion matrix by coordinate axes
+%rotation
+%   inputs:
+%       D -- Distortion matrix 
+%       angle -- angle by which you want to rotate the basis vectors of the
+%       distortion matrix
+
+%   outputs:
+%       D_rot -- Distortion matrix after rotating the basis vectors by the
+%       given angle
+
+%%This function is part of the PC-STEM Package by Elliot Padgett in the 
+%Muller Group at Cornell University. Function added by Hari (Muller group).
+%Last updated Sept 17, 2021.
+
+[N_x1, N_x2] = size(D.m11);
+
+D_rot = struct('m11', nan(N_x1,N_x2), 'm22', nan(N_x1,N_x2),'m12', nan(N_x1,N_x2), 'm21', nan(N_x1,N_x2));
+
+mat = zeros(2,2);
+rot = zeros(2,2);
+rot(1,1) = cosd(angle);
+rot(1,2) = -sind(angle);
+rot(2,1) = sind(angle);
+rot(2,2) = cosd(angle);
+
+for i =1:N_x1
+    for j = 1:N_x2
+       
+       mat(1,1) = D.m11(i,j);
+       mat(1,2) = D.m12(i,j);
+       mat(2,1) = D.m21(i,j);
+       mat(2,2) = D.m22(i,j);
+       
+       temp_mat = rot * mat / rot; 
+       
+       D_rot.m11(i,j) = temp_mat(1,1);
+       D_rot.m12(i,j) = temp_mat(1,2);
+       D_rot.m21(i,j) = temp_mat(2,1);
+       D_rot.m22(i,j) = temp_mat(2,2);
+    end
+end
+end

--- a/distortion_mat.m
+++ b/distortion_mat.m
@@ -1,0 +1,75 @@
+function [ D ] = distortion_mat( spotMaps, spotReferences)
+%From the EWPC peak positions at each pixel stored in spotMaps, calculates the
+%affine transformation required to map to the reference positions.
+%   inputs:
+%       spotMaps -- struct array containing maps of maximum spot index Q1,Q2
+%                 for each spot in spotList. Fields are:
+%                 'id' -- a name identifying the spot.
+%                 'Q1map' -- map of Q1 index value at peak maximum.
+%                 'Q2map' -- map of Q2 index value at peak maximum.
+%                 'x1map' -- map of x1 vector component for the spot.
+%                 'x2map' -- map of x2 vector component for the spot.
+%                 'spotlength' -- map of the spot vector length.
+%                 'spotangle' -- map of the spot vector angle in degrees.
+%       spotReferences -- struct array containing reference points
+%                         corresponding to points in Qmaps. Fields are:
+%                         'id' -- a name identifying the spot.
+%                         'point' -- reference spot location [q1,q2]
+%   outputs:
+%       D -- Distortion matrix that represents the affine
+%       transformation between EWPC peak positions at each pixel to the
+%       reference positions.
+%
+%This function is part of the PC-STEM Package by Elliot Padgett in the 
+%Muller Group at Cornell University.  Last updated June 26, 2019.
+
+%initialize data info
+[Nx1,Nx2] = size(spotMaps(1).Q1map);
+
+%prealocate results structs
+D = struct('m11', nan(Nx1,Nx2), 'm22', nan(Nx1,Nx2),...
+                          'm12', nan(Nx1,Nx2), 'm21', nan(Nx1,Nx2));
+
+%prepare reference point list
+referencePoints = [0,0];
+for s = 1:length(spotReferences)
+    referencePoints = [referencePoints; spotReferences(s).point];
+end
+
+%calculate strain across map
+for j=1:Nx1
+    for k=1:Nx2
+        
+        dataPoints = [0,0];
+        for s = 1:length(spotReferences)
+            %center spot
+            q1c = spotMaps(s).VectorX1(j,k);
+            q2c = spotMaps(s).VectorX2(j,k);
+            
+            %include in list for tranformation calculation
+            dataPoints = [dataPoints; [q1c,q2c]];
+        end
+        if sum(isnan(dataPoints(:)))
+            %nan values mean values are unknown and this point should
+            %be skipped
+
+            D.m11(j,k) = nan;
+            D.m12(j,k) = nan;
+            D.m21(j,k) = nan;
+            D.m22(j,k) = nan;
+
+        else
+            %Calculate transform
+            %tform = fitgeotrans(movingPoints,fixedPoints,'affine');
+            % we want to know what it would be like if we mapped the
+            % reference lattice onto our actual data
+            tform = fitgeotrans(referencePoints,dataPoints,'affine');
+            M=tform.T; M = M(1:2,1:2);
+            D.m11(j,k) = M(1,1);
+            D.m12(j,k) = M(1,2);
+            D.m21(j,k) = M(2,1);
+            D.m22(j,k) = M(2,2);
+            
+        end
+    end
+end

--- a/distortion_mat.m
+++ b/distortion_mat.m
@@ -31,7 +31,7 @@ D = struct('m11', nan(Nx1,Nx2), 'm22', nan(Nx1,Nx2),...
                           'm12', nan(Nx1,Nx2), 'm21', nan(Nx1,Nx2));
 
 %prepare reference point list
-referencePoints = [0,0];
+referencePoints = [];
 for s = 1:length(spotReferences)
     referencePoints = [referencePoints; spotReferences(s).point];
 end
@@ -40,7 +40,7 @@ end
 for j=1:Nx1
     for k=1:Nx2
         
-        dataPoints = [0,0];
+        dataPoints = [];
         for s = 1:length(spotReferences)
             %center spot
             q1c = spotMaps(s).VectorX1(j,k);
@@ -59,12 +59,9 @@ for j=1:Nx1
             D.m22(j,k) = nan;
 
         else
-            %Calculate transform
-            %tform = fitgeotrans(movingPoints,fixedPoints,'affine');
-            % we want to know what it would be like if we mapped the
-            % reference lattice onto our actual data
-            tform = fitgeotrans(referencePoints,dataPoints,'affine');
-            M=tform.T; M = M(1:2,1:2);
+            %Calculate distorion/deformation matrix
+            
+            M = dataPoints /(referencePoints);
             D.m11(j,k) = M(1,1);
             D.m12(j,k) = M(1,2);
             D.m21(j,k) = M(2,1);

--- a/ewpc_mapSpots.m
+++ b/ewpc_mapSpots.m
@@ -22,7 +22,7 @@ function [ spotMaps ] = ewpc_mapSpots( data4d,spotList,tol,valid)
 %                 'spotangle' -- map of the spot vector angle in degrees.
 %
 %This function is part of the PC-STEM Package by Elliot Padgett in the 
-%Muller Group at Cornell University.  Last updated June 26, 2019.
+%Muller Group at Cornell University.  Last updated by Hari on Sept 19, 2021.
 
 %initialize data info
 [N_k1,N_k2,N_x1,N_x2]=size(data4d);
@@ -95,7 +95,7 @@ t=toc;
 fprintf('\nDone. Total time: %.1f s. Time per peak fit: %.3f s.\n',t,t/totalspots)
 
 % Add vector-form maps to spotMaps struct
-spotMaps = calculateSpotMapVectors( spotMaps);
+spotMaps = calculateSpotMapVectors( spotMaps, N_k1, N_k2);
 
 end
 
@@ -125,18 +125,30 @@ w=maskr.*maskc;
 end
 
 %%
-function [ spotMaps_updated ] = calculateSpotMapVectors( spotMaps)
+function [ spotMaps_updated ] = calculateSpotMapVectors( spotMaps, N_k1, N_k2)
 %calculateSpotMapVectors Calculates vector components, length, and angle 
-%   assuming detector has 124 pixels, i.e. zero=(63,63). These are added to
-%   the spotMaps struct
+%  These are added to the spotMaps struct
+mid_x = 0;
+mid_y = 0;
+if(mod(N_k1,2)==0)
+    mid_x = round(N_k1/2) + 1;
+else
+    mid_x = ceil(N_k1/2);
+end
+
+if(mod(N_k2,2)==0)
+    mid_y = round(N_k2/2) + 1;
+else
+    mid_y = ceil(N_k2/2);
+end
 
 numSpots = length(spotMaps);
 spotMaps_updated=spotMaps;
 for i=1:numSpots
     x1map=spotMaps(i).Q1map;
-    x1map=x1map-63; x1map(x1map>62) = x1map(x1map>62)- 124;
+    x1map=x1map-mid_x; x1map(x1map>(mid_x-1)) = x1map(x1map>(mid_x-1))- N_k1;
     x2map=spotMaps(i).Q2map;
-    x2map=x2map-63; x2map(x2map>62) = x2map(x2map>62)- 124;
+    x2map=x2map-mid_y; x2map(x2map>(mid_y-1)) = x2map(x2map>(mid_y-1))- N_k2;
     
     spotlength=sqrt(x1map.^2+x2map.^2);
     spotangle=atan2d(x1map,x2map);


### PR DESCRIPTION
1) Functions added for rotation of strain tensor basis vectors, and for transformation from non-orthogonal to orthogonal basis vectors.
2) ewpc_mapSpots function modified to calculate the EWPC central spot from the number of pixels in diffraction space, rather than assuming that the center is at (63,63) which is the case only for EMPAD 1 detector.